### PR TITLE
Consistency/bug fixes

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -14,13 +14,13 @@
 
 ```
 Usage of ./networkqualityd:
-  -base-port int
+  -config-port int
     	The base port to listen on (default 4043)
   -cert-file string
     	cert to use
   -debug
     	enable debug mode
-  -domain string
+  -config-name string
     	domain to generate config for (default "networkquality.example.com")
   -key-file string
     	key to use


### PR DESCRIPTION
1. Rename `domain` to `config-name` to match all nomenclature in
documentation
2. Configure the connections performing the measurement to use the
same port as the config requests; rename the `-base-port` option to
`-config-port`.
3. Listen for debugging connections on the same address as the user
specified with the `-listen-address` CLI option.