### PR TITLE
Docker configuration and README updates

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -22,11 +22,11 @@ RUN go build -o networkqualityd ./networkqualityd.go
 ENV cert_file=/live/fullchain.pem
 ENV key_file=/live/privkey.pem
 ENV public_name=networkquality.example.com
-ENV domain=networkquality.example.com
-ENV base_port=4043
+ENV config_name=networkquality.example.com
+ENV config_port=4043
 ENV listen_addr=0.0.0.0
 ENV template=config.json.in
 
 # By default, this is what the container will run when `docker run`
 # is issued by a user.
-CMD /server/networkqualityd -cert-file ${cert_file} -key-file ${key_file} -public-name ${public_name} -base-port ${base_port} -domain ${domain} ${debug} -listen-addr ${listen_addr} -template ${template}
+CMD /server/networkqualityd -cert-file ${cert_file} -key-file ${key_file} -public-name ${public_name} -config-port ${config_port} -config-name ${config_name} ${debug} -listen-addr ${listen_addr} -template ${template}

--- a/go/README.md
+++ b/go/README.md
@@ -90,8 +90,8 @@ You can use environment variables to configure any of the `networkqualityd` comm
 | -- | -- |
 | `-cert-file` | `cert_file` |
 | `-key-file` | `key_file` |
-| `-base-port` | `base_port` |
-| `-domain` | `domain` |
+| `-config-port` | `config_port` |
+| `-config-name` | `config_name` |
 | `-listen-addr` | `listen_addr` |
 | `-public-name` | `public_name` |
 | `-template` | `template` |

--- a/go/docker_config.env
+++ b/go/docker_config.env
@@ -4,11 +4,11 @@ cert_file=/live/fullchain.pem
 # The server will look for its SSL private key file in
 # /live/fullchain.pem _in the fs space of the container_.
 key_file=/live/privkey.pem
-# Set the public and domain name to a default.
+# Set the public and config names to a default.
 public_name=networkquality.example.com
-domain=networkquality.example.com
+config_name=networkquality.example.com
 # The config server will listen on this port.
-base_port=4043
+config_port=4043
 # The RPM server will listen on this IP address.
 listen_addr=0.0.0.0
 # The name of the file _in the fs space of the container_


### PR DESCRIPTION
After the most recent updates to the go implementation of the server to
address some consistency issues, the Docker file and the README file
fell out of date. These changes will correct outdated references to
older versions of command line options.